### PR TITLE
Convert passing handler to webserver component to passing a handler component

### DIFF
--- a/src/main/clojure/trellis/webserver.clj
+++ b/src/main/clojure/trellis/webserver.clj
@@ -10,23 +10,39 @@
    :headers {"Content-Type" "text/html"}
    :body    "Trellis Default Ring Handler"})
 
-(defrecord WebServer []
+(defrecord WebServer [port]
   component/Lifecycle
-	  (start [this]
-	    (let [handler (or (:handler this) (error "No :handler specified for web server"))
-            port (or (:port this) (error "No :port specified for web server")) 
-            server (try
-                     (hks/run-server handler {:port port})
-                     (catch Throwable t
-                       (throw (java.lang.Error.
-                                (str "Error starting server for component: " (pr-str this))
-                                t))))]
-	          (assoc this :server server)))
-	
-	  (stop [this]
-	    (when-let [server (:server this)]
-	      (server :timeout 100) ;; calling the server function shuts down the server
-	      (dissoc this :server))))
+  (start [component]
+    (let [handler (or (:handler (:handler component)) 
+                      (error "No handler was provided as part of the handler 
+                              component supplied to the web component"))
+          port (or port (error "No :port specified for web server")) 
+          server (try
+                   (hks/run-server handler {:port port})
+                   (catch Throwable t
+                     (throw (java.lang.Error.
+                              (str "Error starting server for component: " (pr-str component))
+                              t))))]
+      (assoc component :server server)))
+
+  (stop [component]
+    (when-let [server (:server component)]
+      (server :timeout 100) ;; calling the server function shuts down the server
+      (dissoc component :server))))
+
+(defn new-web-server [port]
+  (map->WebServer {:port port}))
+
+; Dummy handler component 
+; Generally you will want to implement your own handler component
+; to do the setup and tear down
+(defrecord Handler [handler]
+  component/Lifecycle
+  (start [component])
+  (stop [component]))
+
+(defn new-handler [handler]
+  (map->Handler {:handler handler}))
 
 (defn server
   "Creates a WebServer component with the given ring handler and options map.
@@ -36,5 +52,5 @@
     (server handler {}))
   ([handler opts]
     (let [opts (if (:port opts) opts (assoc opts :port DEFAULT-PORT))
-          opts (assoc opts :handler handler)]
+          opts (assoc opts :handler (new-handler handler))]
       (map->WebServer opts))))

--- a/src/test/clojure/trellis/test_webserver.clj
+++ b/src/test/clojure/trellis/test_webserver.clj
@@ -19,7 +19,7 @@
 (deftest test-with-component
   (with-component [ws (web/server web/DEFAULT-HANDLER {:port 8801})]
     ;; (println (str ws))
-    (is (== 200 (:status ((:handler ws) {}))))
+    (is (== 200 (:status ((:handler (:handler ws)) {}))))
 ;    (let [resp @(http/get (str "http://127.0.0.1:9999/"))]
 ;      (println resp)
 ;      (is (== 200 (:status resp))))


### PR DESCRIPTION
Handler is now passed as a handler component rather than a stock ring handler. Without this there is no way to create a full system which does anything stateful to the handler or that requires key parts of other system components.
